### PR TITLE
Allow configuring EOL virtual text priority

### DIFF
--- a/lua/inlay-hints/config.lua
+++ b/lua/inlay-hints/config.lua
@@ -26,6 +26,9 @@ local defaults = {
     -- padding from the right if right_align is true
     right_align_padding = 7,
 
+    -- virtual text priority
+    priority = 0,
+
     parameter = {
       separator = ", ",
       format = function(hints)

--- a/lua/inlay-hints/render/eol.lua
+++ b/lua/inlay-hints/render/eol.lua
@@ -83,6 +83,7 @@ function M.render_line(line, line_hints, bufnr, ns)
     virt_text_pos = eol_opts.right_align and "right_align" or "eol",
     virt_text = virt_text,
     hl_mode = "combine",
+    priority = eol_opts.priority,
   })
 end
 


### PR DESCRIPTION
The user may choose to keep EOL inlay hints closer to the code when there are multiple virtual texts (e.g. git blame) for the current line.