### PR TITLE
feat: configure tsserver adapter if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ require("inlay-hints").setup({
   eol = {
     right_align = true,
   }
+
+  adapter = {
+    -- one of:
+    -- - force: use adapter for tsserver always
+    -- - disable: never adapt inlay hints for tsserver
+    -- - auto: checks whether the tsserver provides this capability as a standard one or adapts the request otherwise
+    tsserver = 'auto',
+  }
 })
 ```
 Take a look at all the possible configuration options [here](https://github.com/simrat39/inlay-hints.nvim/blob/main/lua/inlay-hints/config.lua#L3)

--- a/lua/inlay-hints/adapter/init.lua
+++ b/lua/inlay-hints/adapter/init.lua
@@ -5,9 +5,10 @@ local default = require("inlay-hints.adapter.default")
 local M = {}
 
 function M.adapt_request(client, bufnr, callback)
-  if client.name == "tsserver" then
-    tsserver.adapt_request(client, bufnr, callback)
-  elseif client.name == "clangd" then
+  -- if client.name == "tsserver" then
+  --   tsserver.adapt_request(client, bufnr, callback)
+  -- elseif client.name == "clangd" then
+  if client.name == "clangd" then
     clangd.adapt_request(client, bufnr, callback)
   else
     default.adapt_request(client, bufnr, callback)

--- a/lua/inlay-hints/adapter/init.lua
+++ b/lua/inlay-hints/adapter/init.lua
@@ -5,11 +5,29 @@ local ih = require("inlay-hints")
 
 local M = {}
 
-function M.adapt_request(client, bufnr, callback)
-  local opts = ih.config.options or {}
-  local adapter = opts.adapter or {}
+--- Checks the user configuration for adapting the current LSP calls for inlay hints
+--- given the following criteria:
+--- - force: use adapter always depending on the custom implementation of the server (previous behavior)
+--- - disable: never adapt requests, using the default support for inlays in LSP
+--- - auto: checks whether the current server provides this capability as a standard LSP one or adapts the request otherwise
+--- Returns true to adapt the request, false to use the standard method
+--- @return boolean
+local function should_apply_tsserver_adapter(client)
+  local mode = ih.config.options.adapter.tsserver
 
-  if client.name == "tsserver" and adapter.tsserver then
+  if mode == 'force' then
+    return true
+  elseif mode == 'auto' then
+    -- as per current implementation of the typescript-language-server and protocol spec
+    -- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_inlayHint
+    return not client.server_capabilities.inlayHintProvider
+  else -- assume 'disable'
+    return false
+  end
+end
+
+function M.adapt_request(client, bufnr, callback)
+  if client.name == "tsserver" and should_apply_tsserver_adapter(client) then
     tsserver.adapt_request(client, bufnr, callback)
   elseif client.name == "clangd" then
     clangd.adapt_request(client, bufnr, callback)

--- a/lua/inlay-hints/adapter/init.lua
+++ b/lua/inlay-hints/adapter/init.lua
@@ -1,14 +1,17 @@
 local tsserver = require("inlay-hints.adapter.tsserver")
 local clangd = require("inlay-hints.adapter.clangd")
 local default = require("inlay-hints.adapter.default")
+local ih = require("inlay-hints")
 
 local M = {}
 
 function M.adapt_request(client, bufnr, callback)
-  -- if client.name == "tsserver" then
-  --   tsserver.adapt_request(client, bufnr, callback)
-  -- elseif client.name == "clangd" then
-  if client.name == "clangd" then
+  local opts = ih.config.options or {}
+  local adapter = opts.adapter or {}
+
+  if client.name == "tsserver" and adapter.tsserver then
+    tsserver.adapt_request(client, bufnr, callback)
+  elseif client.name == "clangd" then
     clangd.adapt_request(client, bufnr, callback)
   else
     default.adapt_request(client, bufnr, callback)

--- a/lua/inlay-hints/config.lua
+++ b/lua/inlay-hints/config.lua
@@ -40,6 +40,10 @@ local defaults = {
       end,
     },
   },
+
+  adapter = {
+    tsserver = true,
+  }
 }
 
 M.options = {}

--- a/lua/inlay-hints/config.lua
+++ b/lua/inlay-hints/config.lua
@@ -42,7 +42,11 @@ local defaults = {
   },
 
   adapter = {
-    tsserver = true,
+    -- one of:
+    -- - force: use adapter for tsserver always
+    -- - disable: never adapt inlay hints for tsserver
+    -- - auto: checks whether the tsserver provides this capability as a standard one or adapts the request otherwise
+    tsserver = 'auto',
   }
 }
 


### PR DESCRIPTION
Addresses #10 .

Adds a configuration parameter for `tsserver` given that current implementations of LSP for Typescript started supporting the standard and dropping previous custom formats, see [typescript-language-server](https://github.com/typescript-language-server/typescript-language-server#inlay-hints-textdocumentinlayhint).

This was helpful in my case as I was not getting the inlays with the adapter and had this LSP already running in my Neovim setup.

The change still let's a user `force` adapting the request to the custom format, `disable` it altogether or `auto`matically check whether the server provides support to adapt the request or not.